### PR TITLE
【7】トランザクション管理の改善

### DIFF
--- a/business/category_regist_service.py
+++ b/business/category_regist_service.py
@@ -4,6 +4,8 @@ from typing import List
 from injector import inject
 import logging
 from business.abstract_service import AbstractService, AbstractInDto, AbstractOutDto
+from business.decorators.session_manager import SessionManager
+from business.decorators.database_enum import Database
 from domain.repository.test2.category_repository import CategoryRepository
 from domain.model.test2.category import Category
 from business.vo.category_vo import CategoryVo
@@ -31,6 +33,7 @@ class CategoryRegistService(AbstractCategoryRegistService):
     def __post_init__(self):
         self.logger = logging.getLogger(__name__)
 
+    @SessionManager(database=Database.TEST2)
     def execute(self, in_dto: CategoryRegistInDto) -> CategoryRegistOutDto:
         self.logger.info("=== Starting Category Registration ===")
 

--- a/business/decorators/database_enum.py
+++ b/business/decorators/database_enum.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+
+class Database(str, Enum):
+    """
+    Database identifier enum for multi-database architecture
+
+    Attributes:
+        TEST1: User management database
+        TEST2: Product management database
+    """
+    TEST1 = 'test1'
+    TEST2 = 'test2'

--- a/business/decorators/session_manager.py
+++ b/business/decorators/session_manager.py
@@ -10,12 +10,16 @@ logger = logging.getLogger(__name__)
 
 class SessionManager:
     """
-    セッション管理を行うデコレーター
-    メソッドの実行前にセッションを開始し、正常終了時はコミット、エラー時はロールバック、
-    最終的にセッションをクローズする
+    Decorator for automatic session and transaction management
 
     This decorator provides automatic transaction management for service methods.
     It eliminates the need for manual session handling in business logic.
+
+    The decorator automatically:
+    - Starts a session before method execution
+    - Commits the transaction on successful completion
+    - Rolls back the transaction on error
+    - Closes the session in all cases
 
     Usage:
         @SessionManager(database=Database.TEST1)
@@ -82,29 +86,29 @@ class SessionManager:
         @functools.wraps(func)
         def wrapper(instance: Any, *args, **kwargs) -> Any:
             """
-            デコレートされたメソッドを実行し、セッション管理を行う
+            Execute the decorated method with session management
 
             Args:
-                instance: デコレートされたメソッドを持つインスタンス
-                *args: メソッドの引数
-                **kwargs: メソッドのキーワード引数
+                instance: Instance that owns the decorated method
+                *args: Method arguments
+                **kwargs: Method keyword arguments
 
             Returns:
-                メソッドの実行結果
+                Method execution result
             """
             session = None
             try:
-                # SessionHolderからセッションを取得
+                # Get session from SessionHolder
                 session = SessionHolder.get_session(self.database.value)
                 session.begin()
                 logger.info(
                     f"Session started for {self.database.value} and transaction began"
                 )
 
-                # デコレートされたメソッドを実行（sessionを渡さない）
+                # Execute the decorated method
                 result = func(instance, *args, **kwargs)
 
-                # 正常終了時はコミット
+                # Commit on success
                 session.commit()
                 logger.info(
                     f"Transaction committed successfully for {self.database.value}"
@@ -112,7 +116,7 @@ class SessionManager:
                 return result
 
             except Exception as e:
-                # エラー発生時はロールバック
+                # Rollback on error
                 if session:
                     session.rollback()
                     logger.error(
@@ -121,7 +125,7 @@ class SessionManager:
                 logger.error(f"Error in {func.__name__}: {str(e)}")
                 raise
             finally:
-                # セッションをクローズ
+                # Close session
                 if session:
                     session.close()
                     logger.info(f"Session closed for {self.database.value}")

--- a/business/decorators/session_manager.py
+++ b/business/decorators/session_manager.py
@@ -3,6 +3,7 @@ import logging
 from typing import Callable, Any, Union
 from sqlalchemy.orm import Session
 from business.decorators.database_enum import Database
+from domain.session_holder import SessionHolder
 
 logger = logging.getLogger(__name__)
 
@@ -93,8 +94,8 @@ class SessionManager:
             """
             session = None
             try:
-                # データベース別にセッションを取得
-                session = instance.db_session.get_session(self.database.value)
+                # SessionHolderからセッションを取得
+                session = SessionHolder.get_session(self.database.value)
                 session.begin()
                 logger.info(
                     f"Session started for {self.database.value} and transaction began"

--- a/business/decorators/session_manager.py
+++ b/business/decorators/session_manager.py
@@ -1,9 +1,11 @@
 import functools
 import logging
-from typing import Callable, Any
+from typing import Callable, Any, Union
 from sqlalchemy.orm import Session
+from business.decorators.database_enum import Database
 
 logger = logging.getLogger(__name__)
+
 
 class SessionManager:
     """
@@ -11,20 +13,60 @@ class SessionManager:
     メソッドの実行前にセッションを開始し、正常終了時はコミット、エラー時はロールバック、
     最終的にセッションをクローズする
 
+    This decorator provides automatic transaction management for service methods.
+    It eliminates the need for manual session handling in business logic.
+
     Usage:
-        @SessionManager(database='test1')
+        @SessionManager(database=Database.TEST1)
         def some_method(self, input_dto: InDto) -> OutDto:
+            # Your business logic here
+            # Session is automatically managed
             pass
+
+    Args:
+        database: Database identifier (Database.TEST1 for user management,
+                  Database.TEST2 for product management)
+
+    Raises:
+        ValueError: If an invalid database name is provided
+
+    Example:
+        @dataclass
+        class UserService:
+            db_session: DatabaseSession = inject
+
+            @SessionManager(database=Database.TEST1)
+            def create_user(self, user_dto: UserDto) -> UserDto:
+                # Session lifecycle is managed automatically
+                return self.user_repository.create(user_dto)
     """
 
-    def __init__(self, database: str) -> None:
+    def __init__(self, database: Union[Database, str]) -> None:
         """
         Initialize SessionManager decorator
 
         Args:
-            database: Database name ('test1' or 'test2')
+            database: Database identifier (Database enum or string 'test1'/'test2')
+
+        Raises:
+            ValueError: If database name is invalid
         """
-        self.database = database
+        # 文字列の場合はEnumに変換を試みる
+        if isinstance(database, str):
+            try:
+                self.database = Database(database)
+            except ValueError:
+                valid_options = [db.value for db in Database]
+                raise ValueError(
+                    f"Invalid database name: {database}. "
+                    f"Valid options: {valid_options}"
+                )
+        elif isinstance(database, Database):
+            self.database = database
+        else:
+            raise TypeError(
+                f"database must be Database enum or str, got {type(database).__name__}"
+            )
 
     def __call__(self, func: Callable) -> Callable:
         """
@@ -52,35 +94,35 @@ class SessionManager:
             session = None
             try:
                 # データベース別にセッションを取得
-                if self.database == 'test1':
-                    session = instance.db_session.get_session('test1')
-                elif self.database == 'test2':
-                    session = instance.db_session.get_session('test2')
-                else:
-                    raise ValueError(f"Invalid database name: {self.database}")
-
+                session = instance.db_session.get_session(self.database.value)
                 session.begin()
-                logger.info(f"Session started for {self.database} and transaction began")
+                logger.info(
+                    f"Session started for {self.database.value} and transaction began"
+                )
 
                 # デコレートされたメソッドを実行（sessionを渡さない）
                 result = func(instance, *args, **kwargs)
 
                 # 正常終了時はコミット
                 session.commit()
-                logger.info(f"Transaction committed successfully for {self.database}")
+                logger.info(
+                    f"Transaction committed successfully for {self.database.value}"
+                )
                 return result
 
             except Exception as e:
                 # エラー発生時はロールバック
                 if session:
                     session.rollback()
-                    logger.error(f"Transaction rolled back due to error for {self.database}")
+                    logger.error(
+                        f"Transaction rolled back due to error for {self.database.value}"
+                    )
                 logger.error(f"Error in {func.__name__}: {str(e)}")
                 raise
             finally:
                 # セッションをクローズ
                 if session:
                     session.close()
-                    logger.info(f"Session closed for {self.database}")
+                    logger.info(f"Session closed for {self.database.value}")
 
         return wrapper

--- a/business/decorators/session_manager.py
+++ b/business/decorators/session_manager.py
@@ -10,56 +10,77 @@ class SessionManager:
     セッション管理を行うデコレーター
     メソッドの実行前にセッションを開始し、正常終了時はコミット、エラー時はロールバック、
     最終的にセッションをクローズする
+
+    Usage:
+        @SessionManager(database='test1')
+        def some_method(self, input_dto: InDto) -> OutDto:
+            pass
     """
-    
-    def __init__(self, func: Callable) -> None:
-        self.func = func
-        functools.update_wrapper(self, func)
-    
-    def __call__(self, instance: Any, *args, **kwargs) -> Any:
+
+    def __init__(self, database: str) -> None:
         """
-        デコレートされたメソッドを実行し、セッション管理を行う
-        
+        Initialize SessionManager decorator
+
         Args:
-            instance: デコレートされたメソッドを持つインスタンス
-            *args: メソッドの引数
-            **kwargs: メソッドのキーワード引数
-            
+            database: Database name ('test1' or 'test2')
+        """
+        self.database = database
+
+    def __call__(self, func: Callable) -> Callable:
+        """
+        Decorator implementation
+
+        Args:
+            func: Function to be decorated
+
         Returns:
-            メソッドの実行結果
+            Wrapped function
         """
-        session = None
-        try:
-            # セッション開始
-            session = instance.db_session.get_session()
-            session.begin()
-            logger.info("Session started and transaction began")
-            
-            # デコレートされたメソッドを実行（sessionを第一引数として渡す）
-            result = self.func(instance, session, *args, **kwargs)
-            
-            # 正常終了時はコミット
-            session.commit()
-            logger.info("Transaction committed successfully")
-            return result
-            
-        except Exception as e:
-            # エラー発生時はロールバック
-            if session:
-                session.rollback()
-                logger.error("Transaction rolled back due to error")
-            logger.error(f"Error in {self.func.__name__}: {str(e)}")
-            raise
-        finally:
-            # セッションをクローズ
-            if session:
-                session.close()
-                logger.info("Session closed")
-    
-    def __get__(self, instance, owner):
-        """
-        デスクリプタプロトコルをサポートして、インスタンスメソッドとして正しく動作させる
-        """
-        if instance is None:
-            return self
-        return functools.partial(self.__call__, instance)
+        @functools.wraps(func)
+        def wrapper(instance: Any, *args, **kwargs) -> Any:
+            """
+            デコレートされたメソッドを実行し、セッション管理を行う
+
+            Args:
+                instance: デコレートされたメソッドを持つインスタンス
+                *args: メソッドの引数
+                **kwargs: メソッドのキーワード引数
+
+            Returns:
+                メソッドの実行結果
+            """
+            session = None
+            try:
+                # データベース別にセッションを取得
+                if self.database == 'test1':
+                    session = instance.db_session.get_session('test1')
+                elif self.database == 'test2':
+                    session = instance.db_session.get_session('test2')
+                else:
+                    raise ValueError(f"Invalid database name: {self.database}")
+
+                session.begin()
+                logger.info(f"Session started for {self.database} and transaction began")
+
+                # デコレートされたメソッドを実行（sessionを渡さない）
+                result = func(instance, *args, **kwargs)
+
+                # 正常終了時はコミット
+                session.commit()
+                logger.info(f"Transaction committed successfully for {self.database}")
+                return result
+
+            except Exception as e:
+                # エラー発生時はロールバック
+                if session:
+                    session.rollback()
+                    logger.error(f"Transaction rolled back due to error for {self.database}")
+                logger.error(f"Error in {func.__name__}: {str(e)}")
+                raise
+            finally:
+                # セッションをクローズ
+                if session:
+                    session.close()
+                    logger.info(f"Session closed for {self.database}")
+
+        return wrapper

--- a/business/depart_user_regist_service.py
+++ b/business/depart_user_regist_service.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from typing import List
 from injector import inject
 import logging
-from sqlalchemy.orm import Session
 from business.abstract_service import AbstractService, AbstractInDto, AbstractOutDto
 from business.department_regist_service import DepartmentRegistService, DepartmentRegistInDto
 from business.user_regist_service import UserRegistService, UserRegistInDto
@@ -46,8 +45,8 @@ class DepartUserRegistService(AbstractDepartUserRegistService):
     def execute(self, in_dto: DepartUserRegistInDto) -> DepartUserRegistOutDto:
         return self.regist_depart_user(in_dto)
     
-    @SessionManager
-    def regist_depart_user(self, session: Session, input_dto: DepartUserRegistInDto) -> DepartUserRegistOutDto:
+    @SessionManager(database='test1')
+    def regist_depart_user(self, input_dto: DepartUserRegistInDto) -> DepartUserRegistOutDto:
         self.logger.info("=== Starting Department and User Registration ===")
         
         # 1. Department registration

--- a/business/depart_user_regist_service.py
+++ b/business/depart_user_regist_service.py
@@ -8,7 +8,6 @@ from business.department_regist_service import DepartmentRegistService, Departme
 from business.user_regist_service import UserRegistService, UserRegistInDto
 from business.decorators.session_manager import SessionManager
 from business.decorators.database_enum import Database
-from domain.database import DatabaseSession
 from business.vo.department_vo import DepartmentVo
 from business.vo.user_vo import UserVo
 
@@ -38,7 +37,6 @@ class AbstractDepartUserRegistService(AbstractService):
 class DepartUserRegistService(AbstractDepartUserRegistService):
     department_regist_service: DepartmentRegistService
     user_regist_service: UserRegistService
-    db_session: DatabaseSession
 
     def __post_init__(self):
         self.logger = logging.getLogger(__name__)

--- a/business/depart_user_regist_service.py
+++ b/business/depart_user_regist_service.py
@@ -7,6 +7,7 @@ from business.abstract_service import AbstractService, AbstractInDto, AbstractOu
 from business.department_regist_service import DepartmentRegistService, DepartmentRegistInDto
 from business.user_regist_service import UserRegistService, UserRegistInDto
 from business.decorators.session_manager import SessionManager
+from business.decorators.database_enum import Database
 from domain.database import DatabaseSession
 from business.vo.department_vo import DepartmentVo
 from business.vo.user_vo import UserVo
@@ -45,7 +46,7 @@ class DepartUserRegistService(AbstractDepartUserRegistService):
     def execute(self, in_dto: DepartUserRegistInDto) -> DepartUserRegistOutDto:
         return self.regist_depart_user(in_dto)
     
-    @SessionManager(database='test1')
+    @SessionManager(database=Database.TEST1)
     def regist_depart_user(self, input_dto: DepartUserRegistInDto) -> DepartUserRegistOutDto:
         self.logger.info("=== Starting Department and User Registration ===")
         

--- a/business/product_regist_service.py
+++ b/business/product_regist_service.py
@@ -4,6 +4,8 @@ from typing import List
 from injector import inject
 import logging
 from business.abstract_service import AbstractService, AbstractInDto, AbstractOutDto
+from business.decorators.session_manager import SessionManager
+from business.decorators.database_enum import Database
 from domain.repository.test2.product_repository import ProductRepository
 from domain.model.test2.product import Product
 from business.vo.product_vo import ProductVo
@@ -31,6 +33,7 @@ class ProductRegistService(AbstractProductRegistService):
     def __post_init__(self):
         self.logger = logging.getLogger(__name__)
 
+    @SessionManager(database=Database.TEST2)
     def execute(self, in_dto: ProductRegistInDto) -> ProductRegistOutDto:
         self.logger.info("=== Starting Product Registration ===")
 

--- a/domain/database.py
+++ b/domain/database.py
@@ -11,6 +11,7 @@ from .model.test1.user_info import UserInfo
 from .model.test2.base import Base as Test2Base
 from .model.test2.category import Category
 from .model.test2.product import Product
+from .session_holder import SessionHolder
 import yaml
 import os
 
@@ -103,6 +104,14 @@ class Test1DatabaseSession(Session):
     def __init__(self, engine: Test1DatabaseEngine):
         super().__init__(bind=engine.get_engine())
         self.engine = engine
+        # SessionHolderに登録
+        self._register_to_session_holder()
+
+    def _register_to_session_holder(self):
+        """SessionHolderにセッションファクトリーを登録"""
+        if not SessionHolder.is_registered('test1'):
+            session_factory = sessionmaker(bind=self.engine.get_engine())
+            SessionHolder.register('test1', session_factory)
 
 # Test2 Database Classes
 @inject
@@ -126,6 +135,14 @@ class Test2DatabaseSession(Session):
     def __init__(self, engine: Test2DatabaseEngine):
         super().__init__(bind=engine.get_engine())
         self.engine = engine
+        # SessionHolderに登録
+        self._register_to_session_holder()
+
+    def _register_to_session_holder(self):
+        """SessionHolderにセッションファクトリーを登録"""
+        if not SessionHolder.is_registered('test2'):
+            session_factory = sessionmaker(bind=self.engine.get_engine())
+            SessionHolder.register('test2', session_factory)
 
 # Legacy classes for backward compatibility (deprecated)
 #

--- a/domain/database.py
+++ b/domain/database.py
@@ -108,7 +108,7 @@ class Test1DatabaseSession(Session):
         self._register_to_session_holder()
 
     def _register_to_session_holder(self):
-        """SessionHolderにセッションファクトリーを登録"""
+        """Register session factory to SessionHolder"""
         if not SessionHolder.is_registered('test1'):
             session_factory = sessionmaker(bind=self.engine.get_engine())
             SessionHolder.register('test1', session_factory)
@@ -139,7 +139,7 @@ class Test2DatabaseSession(Session):
         self._register_to_session_holder()
 
     def _register_to_session_holder(self):
-        """SessionHolderにセッションファクトリーを登録"""
+        """Register session factory to SessionHolder"""
         if not SessionHolder.is_registered('test2'):
             session_factory = sessionmaker(bind=self.engine.get_engine())
             SessionHolder.register('test2', session_factory)

--- a/domain/session_holder.py
+++ b/domain/session_holder.py
@@ -1,0 +1,104 @@
+from typing import Dict, Callable
+from sqlalchemy.orm import Session
+
+
+class SessionHolder:
+    """
+    セッションファクトリーを一元管理するシングルトンクラス
+
+    データベースごとのセッション生成ロジックを登録し、
+    SessionManagerなどから統一的にアクセスできるようにする
+
+    This class provides centralized session factory management.
+    Each database registers its session factory, which can then be
+    accessed by SessionManager and other components.
+
+    Example:
+        # Register session factories during initialization
+        SessionHolder.register('test1', test1_session.get_session)
+        SessionHolder.register('test2', test2_session.get_session)
+
+        # Get session in SessionManager
+        session = SessionHolder.get_session('test1')
+    """
+
+    _session_factories: Dict[str, Callable[[], Session]] = {}
+
+    @classmethod
+    def register(cls, database: str, session_factory: Callable[[], Session]) -> None:
+        """
+        セッションファクトリーを登録
+
+        Register a session factory for a specific database
+
+        Args:
+            database: Database identifier (e.g., 'test1', 'test2')
+            session_factory: Callable that returns a Session instance
+
+        Raises:
+            ValueError: If database is already registered
+        """
+        if database in cls._session_factories:
+            raise ValueError(
+                f"Session factory for database '{database}' is already registered"
+            )
+        cls._session_factories[database] = session_factory
+
+    @classmethod
+    def get_session(cls, database: str) -> Session:
+        """
+        指定されたデータベースのセッションを取得
+
+        Get a session for the specified database
+
+        Args:
+            database: Database identifier
+
+        Returns:
+            Session instance
+
+        Raises:
+            ValueError: If database is not registered
+        """
+        if database not in cls._session_factories:
+            raise ValueError(
+                f"No session factory registered for database '{database}'. "
+                f"Available databases: {list(cls._session_factories.keys())}"
+            )
+        return cls._session_factories[database]()
+
+    @classmethod
+    def is_registered(cls, database: str) -> bool:
+        """
+        指定されたデータベースが登録されているかチェック
+
+        Check if a database is registered
+
+        Args:
+            database: Database identifier
+
+        Returns:
+            True if registered, False otherwise
+        """
+        return database in cls._session_factories
+
+    @classmethod
+    def clear(cls) -> None:
+        """
+        全ての登録をクリア（主にテスト用）
+
+        Clear all registered session factories (mainly for testing)
+        """
+        cls._session_factories.clear()
+
+    @classmethod
+    def get_registered_databases(cls) -> list:
+        """
+        登録されているデータベース一覧を取得
+
+        Get list of registered databases
+
+        Returns:
+            List of registered database identifiers
+        """
+        return list(cls._session_factories.keys())

--- a/domain/session_holder.py
+++ b/domain/session_holder.py
@@ -4,10 +4,7 @@ from sqlalchemy.orm import Session
 
 class SessionHolder:
     """
-    セッションファクトリーを一元管理するシングルトンクラス
-
-    データベースごとのセッション生成ロジックを登録し、
-    SessionManagerなどから統一的にアクセスできるようにする
+    Singleton class for centralized session factory management
 
     This class provides centralized session factory management.
     Each database registers its session factory, which can then be
@@ -27,8 +24,6 @@ class SessionHolder:
     @classmethod
     def register(cls, database: str, session_factory: Callable[[], Session]) -> None:
         """
-        セッションファクトリーを登録
-
         Register a session factory for a specific database
 
         Args:
@@ -47,8 +42,6 @@ class SessionHolder:
     @classmethod
     def get_session(cls, database: str) -> Session:
         """
-        指定されたデータベースのセッションを取得
-
         Get a session for the specified database
 
         Args:
@@ -70,8 +63,6 @@ class SessionHolder:
     @classmethod
     def is_registered(cls, database: str) -> bool:
         """
-        指定されたデータベースが登録されているかチェック
-
         Check if a database is registered
 
         Args:
@@ -85,8 +76,6 @@ class SessionHolder:
     @classmethod
     def clear(cls) -> None:
         """
-        全ての登録をクリア（主にテスト用）
-
         Clear all registered session factories (mainly for testing)
         """
         cls._session_factories.clear()
@@ -94,8 +83,6 @@ class SessionHolder:
     @classmethod
     def get_registered_databases(cls) -> list:
         """
-        登録されているデータベース一覧を取得
-
         Get list of registered databases
 
         Returns:

--- a/tests/business/test_category_regist_service.py
+++ b/tests/business/test_category_regist_service.py
@@ -11,6 +11,7 @@ from business.category_regist_service import CategoryRegistService, CategoryRegi
 from domain.repository.test2.category_repository import CategoryRepository
 from domain.model.test2.category import Category
 from business.vo.category_vo import CategoryVo
+from domain.session_holder import SessionHolder
 
 
 class TestCategoryRegistService:
@@ -18,11 +19,22 @@ class TestCategoryRegistService:
 
     def setup_method(self):
         """Setup method called before each test"""
+        # SessionHolderをクリア
+        SessionHolder.clear()
+
+        # モックセッションを登録
+        mock_session = Mock()
+        SessionHolder.register('test2', lambda: mock_session)
+
         # Create a mock CategoryRepository
         self.mock_repository = Mock(spec=CategoryRepository)
 
         # Create CategoryRegistService instance with mocked dependencies
         self.service = CategoryRegistService(category_repository=self.mock_repository)
+
+    def teardown_method(self):
+        """Teardown method called after each test"""
+        SessionHolder.clear()
 
     def create_category_vo(self, category_name: str, category_description: str = None, parent_category_id: int = None) -> CategoryVo:
         """Helper method to create CategoryVo objects"""

--- a/tests/business/test_product_regist_service.py
+++ b/tests/business/test_product_regist_service.py
@@ -11,6 +11,7 @@ from business.product_regist_service import ProductRegistService, ProductRegistI
 from domain.repository.test2.product_repository import ProductRepository
 from domain.model.test2.product import Product
 from business.vo.product_vo import ProductVo
+from domain.session_holder import SessionHolder
 
 
 class TestProductRegistService:
@@ -18,11 +19,22 @@ class TestProductRegistService:
 
     def setup_method(self):
         """Setup method called before each test"""
+        # SessionHolderをクリア
+        SessionHolder.clear()
+
+        # モックセッションを登録
+        mock_session = Mock()
+        SessionHolder.register('test2', lambda: mock_session)
+
         # Create a mock ProductRepository
         self.mock_repository = Mock(spec=ProductRepository)
 
         # Create ProductRegistService instance with mocked dependencies
         self.service = ProductRegistService(product_repository=self.mock_repository)
+
+    def teardown_method(self):
+        """Teardown method called after each test"""
+        SessionHolder.clear()
 
     def create_product_vo(self, product_name: str, description: str = None, price: float = 99.99,
                          stock_quantity: int = 10, category_id: int = 1) -> ProductVo:

--- a/tests/decorators/__init__.py
+++ b/tests/decorators/__init__.py
@@ -1,0 +1,1 @@
+# Decorators tests package

--- a/tests/decorators/test_session_manager.py
+++ b/tests/decorators/test_session_manager.py
@@ -1,0 +1,247 @@
+import pytest
+from unittest.mock import Mock, MagicMock, patch
+from business.decorators.session_manager import SessionManager
+from business.decorators.database_enum import Database
+
+
+class TestSessionManager:
+    """SessionManagerデコレーターの単体テスト"""
+
+    def test_session_manager_with_enum_test1(self):
+        """TEST1 Enumを使用した正常系テスト"""
+        # Arrange
+        mock_instance = Mock()
+        mock_session = Mock()
+        mock_instance.db_session.get_session.return_value = mock_session
+
+        @SessionManager(database=Database.TEST1)
+        def dummy_method(self):
+            return "success"
+
+        # Act
+        result = dummy_method(mock_instance)
+
+        # Assert
+        assert result == "success"
+        mock_instance.db_session.get_session.assert_called_once_with('test1')
+        mock_session.begin.assert_called_once()
+        mock_session.commit.assert_called_once()
+        mock_session.close.assert_called_once()
+
+    def test_session_manager_with_enum_test2(self):
+        """TEST2 Enumを使用した正常系テスト"""
+        # Arrange
+        mock_instance = Mock()
+        mock_session = Mock()
+        mock_instance.db_session.get_session.return_value = mock_session
+
+        @SessionManager(database=Database.TEST2)
+        def dummy_method(self):
+            return "success"
+
+        # Act
+        result = dummy_method(mock_instance)
+
+        # Assert
+        assert result == "success"
+        mock_instance.db_session.get_session.assert_called_once_with('test2')
+        mock_session.begin.assert_called_once()
+        mock_session.commit.assert_called_once()
+        mock_session.close.assert_called_once()
+
+    def test_session_manager_with_string_test1(self):
+        """文字列'test1'を使用した正常系テスト（後方互換性）"""
+        # Arrange
+        mock_instance = Mock()
+        mock_session = Mock()
+        mock_instance.db_session.get_session.return_value = mock_session
+
+        @SessionManager(database='test1')
+        def dummy_method(self):
+            return "success"
+
+        # Act
+        result = dummy_method(mock_instance)
+
+        # Assert
+        assert result == "success"
+        mock_instance.db_session.get_session.assert_called_once_with('test1')
+        mock_session.begin.assert_called_once()
+        mock_session.commit.assert_called_once()
+        mock_session.close.assert_called_once()
+
+    def test_session_manager_with_string_test2(self):
+        """文字列'test2'を使用した正常系テスト（後方互換性）"""
+        # Arrange
+        mock_instance = Mock()
+        mock_session = Mock()
+        mock_instance.db_session.get_session.return_value = mock_session
+
+        @SessionManager(database='test2')
+        def dummy_method(self):
+            return "success"
+
+        # Act
+        result = dummy_method(mock_instance)
+
+        # Assert
+        assert result == "success"
+        mock_instance.db_session.get_session.assert_called_once_with('test2')
+
+    def test_session_manager_invalid_string_database(self):
+        """無効な文字列データベース名のテスト"""
+        # Act & Assert
+        with pytest.raises(ValueError, match="Invalid database name: invalid"):
+            @SessionManager(database='invalid')
+            def dummy_method(self):
+                pass
+
+    def test_session_manager_invalid_type(self):
+        """無効な型のデータベース指定のテスト"""
+        # Act & Assert
+        with pytest.raises(TypeError, match="database must be Database enum or str"):
+            @SessionManager(database=123)
+            def dummy_method(self):
+                pass
+
+    def test_session_manager_rollback_on_exception(self):
+        """例外発生時のロールバックテスト"""
+        # Arrange
+        mock_instance = Mock()
+        mock_session = Mock()
+        mock_instance.db_session.get_session.return_value = mock_session
+
+        @SessionManager(database=Database.TEST1)
+        def dummy_method(self):
+            raise RuntimeError("Test error")
+
+        # Act & Assert
+        with pytest.raises(RuntimeError, match="Test error"):
+            dummy_method(mock_instance)
+
+        mock_session.begin.assert_called_once()
+        mock_session.rollback.assert_called_once()
+        mock_session.commit.assert_not_called()
+        mock_session.close.assert_called_once()
+
+    def test_session_manager_logging_test1(self, caplog):
+        """TEST1データベースのログ出力テスト"""
+        # Arrange
+        mock_instance = Mock()
+        mock_session = Mock()
+        mock_instance.db_session.get_session.return_value = mock_session
+
+        @SessionManager(database=Database.TEST1)
+        def dummy_method(self):
+            return "success"
+
+        # Act
+        with caplog.at_level('INFO'):
+            dummy_method(mock_instance)
+
+        # Assert
+        assert "Session started for test1 and transaction began" in caplog.text
+        assert "Transaction committed successfully for test1" in caplog.text
+        assert "Session closed for test1" in caplog.text
+
+    def test_session_manager_logging_test2(self, caplog):
+        """TEST2データベースのログ出力テスト"""
+        # Arrange
+        mock_instance = Mock()
+        mock_session = Mock()
+        mock_instance.db_session.get_session.return_value = mock_session
+
+        @SessionManager(database=Database.TEST2)
+        def dummy_method(self):
+            return "success"
+
+        # Act
+        with caplog.at_level('INFO'):
+            dummy_method(mock_instance)
+
+        # Assert
+        assert "Session started for test2 and transaction began" in caplog.text
+        assert "Transaction committed successfully for test2" in caplog.text
+        assert "Session closed for test2" in caplog.text
+
+    def test_session_manager_logging_on_error(self, caplog):
+        """エラー発生時のログ出力テスト"""
+        # Arrange
+        mock_instance = Mock()
+        mock_session = Mock()
+        mock_instance.db_session.get_session.return_value = mock_session
+
+        @SessionManager(database=Database.TEST1)
+        def dummy_method(self):
+            raise ValueError("Test error")
+
+        # Act & Assert
+        with caplog.at_level('ERROR'):
+            with pytest.raises(ValueError):
+                dummy_method(mock_instance)
+
+        assert "Transaction rolled back due to error for test1" in caplog.text
+        assert "Error in dummy_method: Test error" in caplog.text
+
+    def test_session_manager_with_args_and_kwargs(self):
+        """引数とキーワード引数を持つメソッドのテスト"""
+        # Arrange
+        mock_instance = Mock()
+        mock_session = Mock()
+        mock_instance.db_session.get_session.return_value = mock_session
+
+        @SessionManager(database=Database.TEST1)
+        def dummy_method(self, arg1, arg2, kwarg1=None, kwarg2=None):
+            return f"{arg1}-{arg2}-{kwarg1}-{kwarg2}"
+
+        # Act
+        result = dummy_method(mock_instance, "a", "b", kwarg1="c", kwarg2="d")
+
+        # Assert
+        assert result == "a-b-c-d"
+        mock_session.begin.assert_called_once()
+        mock_session.commit.assert_called_once()
+
+    def test_session_manager_preserves_function_metadata(self):
+        """デコレートされた関数のメタデータが保持されることを確認"""
+        # Arrange & Act
+        @SessionManager(database=Database.TEST1)
+        def dummy_method(self):
+            """Test docstring"""
+            pass
+
+        # Assert
+        assert dummy_method.__name__ == "dummy_method"
+        assert dummy_method.__doc__ == "Test docstring"
+
+    def test_session_manager_session_close_on_commit_error(self):
+        """コミット時にエラーが発生してもセッションがクローズされることを確認"""
+        # Arrange
+        mock_instance = Mock()
+        mock_session = Mock()
+        mock_session.commit.side_effect = RuntimeError("Commit failed")
+        mock_instance.db_session.get_session.return_value = mock_session
+
+        @SessionManager(database=Database.TEST1)
+        def dummy_method(self):
+            return "success"
+
+        # Act & Assert
+        with pytest.raises(RuntimeError, match="Commit failed"):
+            dummy_method(mock_instance)
+
+        mock_session.rollback.assert_called_once()
+        mock_session.close.assert_called_once()
+
+    def test_session_manager_valid_database_names_in_error_message(self):
+        """エラーメッセージに有効なデータベース名が含まれることを確認"""
+        # Act & Assert
+        with pytest.raises(ValueError) as exc_info:
+            @SessionManager(database='invalid_db')
+            def dummy_method(self):
+                pass
+
+        error_message = str(exc_info.value)
+        assert "Invalid database name: invalid_db" in error_message
+        assert "test1" in error_message
+        assert "test2" in error_message

--- a/tests/decorators/test_session_manager.py
+++ b/tests/decorators/test_session_manager.py
@@ -2,17 +2,28 @@ import pytest
 from unittest.mock import Mock, MagicMock, patch
 from business.decorators.session_manager import SessionManager
 from business.decorators.database_enum import Database
+from domain.session_holder import SessionHolder
 
 
 class TestSessionManager:
     """SessionManagerデコレーターの単体テスト"""
+
+    def setup_method(self):
+        """各テストの前にSessionHolderをクリア"""
+        SessionHolder.clear()
+
+    def teardown_method(self):
+        """各テストの後にSessionHolderをクリア"""
+        SessionHolder.clear()
 
     def test_session_manager_with_enum_test1(self):
         """TEST1 Enumを使用した正常系テスト"""
         # Arrange
         mock_instance = Mock()
         mock_session = Mock()
-        mock_instance.db_session.get_session.return_value = mock_session
+
+        # SessionHolderにモックセッションファクトリーを登録
+        SessionHolder.register('test1', lambda: mock_session)
 
         @SessionManager(database=Database.TEST1)
         def dummy_method(self):
@@ -23,7 +34,6 @@ class TestSessionManager:
 
         # Assert
         assert result == "success"
-        mock_instance.db_session.get_session.assert_called_once_with('test1')
         mock_session.begin.assert_called_once()
         mock_session.commit.assert_called_once()
         mock_session.close.assert_called_once()
@@ -33,7 +43,9 @@ class TestSessionManager:
         # Arrange
         mock_instance = Mock()
         mock_session = Mock()
-        mock_instance.db_session.get_session.return_value = mock_session
+
+        # SessionHolderにモックセッションファクトリーを登録
+        SessionHolder.register('test2', lambda: mock_session)
 
         @SessionManager(database=Database.TEST2)
         def dummy_method(self):
@@ -44,7 +56,6 @@ class TestSessionManager:
 
         # Assert
         assert result == "success"
-        mock_instance.db_session.get_session.assert_called_once_with('test2')
         mock_session.begin.assert_called_once()
         mock_session.commit.assert_called_once()
         mock_session.close.assert_called_once()
@@ -54,7 +65,9 @@ class TestSessionManager:
         # Arrange
         mock_instance = Mock()
         mock_session = Mock()
-        mock_instance.db_session.get_session.return_value = mock_session
+
+        # SessionHolderにモックセッションファクトリーを登録
+        SessionHolder.register('test1', lambda: mock_session)
 
         @SessionManager(database='test1')
         def dummy_method(self):
@@ -65,7 +78,6 @@ class TestSessionManager:
 
         # Assert
         assert result == "success"
-        mock_instance.db_session.get_session.assert_called_once_with('test1')
         mock_session.begin.assert_called_once()
         mock_session.commit.assert_called_once()
         mock_session.close.assert_called_once()
@@ -75,7 +87,9 @@ class TestSessionManager:
         # Arrange
         mock_instance = Mock()
         mock_session = Mock()
-        mock_instance.db_session.get_session.return_value = mock_session
+
+        # SessionHolderにモックセッションファクトリーを登録
+        SessionHolder.register('test2', lambda: mock_session)
 
         @SessionManager(database='test2')
         def dummy_method(self):
@@ -86,7 +100,9 @@ class TestSessionManager:
 
         # Assert
         assert result == "success"
-        mock_instance.db_session.get_session.assert_called_once_with('test2')
+        mock_session.begin.assert_called_once()
+        mock_session.commit.assert_called_once()
+        mock_session.close.assert_called_once()
 
     def test_session_manager_invalid_string_database(self):
         """無効な文字列データベース名のテスト"""
@@ -109,7 +125,9 @@ class TestSessionManager:
         # Arrange
         mock_instance = Mock()
         mock_session = Mock()
-        mock_instance.db_session.get_session.return_value = mock_session
+
+        # SessionHolderにモックセッションファクトリーを登録
+        SessionHolder.register('test1', lambda: mock_session)
 
         @SessionManager(database=Database.TEST1)
         def dummy_method(self):
@@ -129,7 +147,9 @@ class TestSessionManager:
         # Arrange
         mock_instance = Mock()
         mock_session = Mock()
-        mock_instance.db_session.get_session.return_value = mock_session
+
+        # SessionHolderにモックセッションファクトリーを登録
+        SessionHolder.register('test1', lambda: mock_session)
 
         @SessionManager(database=Database.TEST1)
         def dummy_method(self):
@@ -149,7 +169,9 @@ class TestSessionManager:
         # Arrange
         mock_instance = Mock()
         mock_session = Mock()
-        mock_instance.db_session.get_session.return_value = mock_session
+
+        # SessionHolderにモックセッションファクトリーを登録
+        SessionHolder.register('test2', lambda: mock_session)
 
         @SessionManager(database=Database.TEST2)
         def dummy_method(self):
@@ -169,7 +191,9 @@ class TestSessionManager:
         # Arrange
         mock_instance = Mock()
         mock_session = Mock()
-        mock_instance.db_session.get_session.return_value = mock_session
+
+        # SessionHolderにモックセッションファクトリーを登録
+        SessionHolder.register('test1', lambda: mock_session)
 
         @SessionManager(database=Database.TEST1)
         def dummy_method(self):
@@ -188,7 +212,9 @@ class TestSessionManager:
         # Arrange
         mock_instance = Mock()
         mock_session = Mock()
-        mock_instance.db_session.get_session.return_value = mock_session
+
+        # SessionHolderにモックセッションファクトリーを登録
+        SessionHolder.register('test1', lambda: mock_session)
 
         @SessionManager(database=Database.TEST1)
         def dummy_method(self, arg1, arg2, kwarg1=None, kwarg2=None):
@@ -220,7 +246,9 @@ class TestSessionManager:
         mock_instance = Mock()
         mock_session = Mock()
         mock_session.commit.side_effect = RuntimeError("Commit failed")
-        mock_instance.db_session.get_session.return_value = mock_session
+
+        # SessionHolderにモックセッションファクトリーを登録
+        SessionHolder.register('test1', lambda: mock_session)
 
         @SessionManager(database=Database.TEST1)
         def dummy_method(self):


### PR DESCRIPTION
## 概要
@SessionManagerデコレーターによるトランザクション管理をしているが、databaseの引数を渡すように改善する

## 変更内容
改善前：
```python
@SessionManager
def regist_depart_user(self, session: Session, input_dto: DepartUserRegistInDto) -> DepartUserRegistOutDto:
```

改善後：
```python
@SessionManager(database='test1')
def regist_depart_user(self, input_dto: DepartUserRegistInDto) -> DepartUserRegistOutDto:
```

## 関連Issue
Closes #7