### PR TITLE
【9】Injectorのログを出力する

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,153 @@
+# Injector Logging Examples
+
+## Overview
+
+This directory contains examples demonstrating how to enable and use debug logging in the `python-injector` library for tracing dependency injection operations.
+
+## Injector Logging Configuration
+
+### Enable Debug Logging
+
+```python
+import logging
+
+# Get the injector logger
+injector_logger = logging.getLogger('injector')
+
+# Set level to DEBUG
+injector_logger.setLevel(logging.DEBUG)
+
+# Add a handler
+handler = logging.StreamHandler()
+handler.setLevel(logging.DEBUG)
+injector_logger.addHandler(handler)
+```
+
+### Available Log Messages
+
+The injector library provides detailed debug logs for:
+
+1. **`Injector.get()`** - Shows:
+   - Interface being requested
+   - Scope being used
+   - Provider handling the request
+   - Resolved result
+
+2. **`create_object()`** - Shows:
+   - Class being instantiated
+   - Additional kwargs being passed
+
+3. **`args_to_inject()`** - Shows:
+   - Bindings being provided
+   - Functions receiving injection
+
+### Log Output Format
+
+The debug logs use indentation (`>`, `>>`, `>>>`, etc.) to show the depth of the dependency tree:
+
+```
+> Injector.get(<class 'UserService'>) using <ClassProvider>
+> Creating <class 'UserService'> object with {}
+> Providing {'user_repository': <class 'UserRepository'>} for __init__
+>> Injector.get(<class 'UserRepository'>) using <ClassProvider>
+>> Creating <class 'UserRepository'> object with {}
+>>> Injector.get(<class 'DatabaseConnection'>) using CallableProvider
+>>>>Injector.get(<class 'DatabaseConfig'>) using CallableProvider (Singleton)
+```
+
+## Running the Examples
+
+### Example 1: Basic Logging
+
+```bash
+python examples/injector_logging_example.py
+```
+
+This demonstrates:
+- Dependency injection without logging
+- Dependency injection with DEBUG logging enabled
+- Singleton behavior verification
+
+### Expected Output
+
+```
+=== Example 1: Without logging ===
+Providing DatabaseConfig
+Providing DatabaseConnection
+Creating DB connection to prod-db.example.com:3306/production
+Fetching users from database
+
+=== Example 2: With DEBUG logging ===
+Providing DatabaseConfig
+Providing DatabaseConnection
+Creating DB connection to prod-db.example.com:3306/production
+Fetching users from database
+2025-10-05 00:24:24 - injector - DEBUG - > Injector.get(<class 'UserService'>)
+2025-10-05 00:24:24 - injector - DEBUG - > Creating <class 'UserService'> object
+...
+```
+
+## Use Cases
+
+### 1. Debugging Injection Issues
+
+Enable logging to see exactly how dependencies are being resolved:
+
+```python
+logging.getLogger('injector').setLevel(logging.DEBUG)
+injector = Injector([MyModule()])
+service = injector.get(MyService)  # See full injection trace
+```
+
+### 2. Verifying Singleton Behavior
+
+Check if singletons are being reused correctly:
+
+```python
+config1 = injector.get(DatabaseConfig)  # First creation logged
+config2 = injector.get(DatabaseConfig)  # Reuse logged (no re-creation)
+```
+
+### 3. Understanding Dependency Trees
+
+Visualize complex dependency hierarchies:
+
+```
+> UserService
+>> UserRepository
+>>> DatabaseConnection
+>>>> DatabaseConfig (Singleton)
+```
+
+## Best Practices
+
+1. **Development Only**: Enable debug logging only in development/testing environments
+2. **Performance**: DEBUG logging adds overhead - disable in production
+3. **Log Levels**: Use different levels for different scenarios:
+   - `DEBUG`: Full injection traces
+   - `INFO`: High-level dependency creation
+   - `WARNING`: Default (minimal logging)
+
+## Integration with Project
+
+To enable injector logging in your application:
+
+```python
+# In your main.py or application setup
+import logging
+
+# Configure injector logging
+if os.getenv('DEBUG', 'false').lower() == 'true':
+    logging.getLogger('injector').setLevel(logging.DEBUG)
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    ))
+    logging.getLogger('injector').addHandler(handler)
+```
+
+## References
+
+- [python-injector GitHub](https://github.com/python-injector/injector)
+- [python-injector Documentation](https://injector.readthedocs.io/)
+- [Python Logging Documentation](https://docs.python.org/3/library/logging.html)

--- a/examples/injector_logging_example.py
+++ b/examples/injector_logging_example.py
@@ -1,0 +1,113 @@
+"""
+Injector Logging Example
+
+This example demonstrates how to enable debug logging for python-injector
+to trace dependency injection operations.
+"""
+
+import logging
+from dataclasses import dataclass
+from injector import Injector, Module, provider, inject, singleton
+
+
+# Configure logging BEFORE creating injector
+def setup_injector_logging():
+    """
+    Enable debug logging for injector to trace dependency injection
+
+    Available log messages:
+    - Injector.get(): Shows interface, scope, and provider being used
+    - create_object(): Shows class being created with kwargs
+    - args_to_inject(): Shows bindings being provided for functions
+    """
+    # Get the injector logger
+    injector_logger = logging.getLogger('injector')
+
+    # Set level to DEBUG to see all injection traces
+    injector_logger.setLevel(logging.DEBUG)
+
+    # Add a handler to output logs
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.DEBUG)
+
+    # Format logs nicely
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    )
+    handler.setFormatter(formatter)
+
+    injector_logger.addHandler(handler)
+
+
+# Example classes
+@dataclass
+class DatabaseConfig:
+    host: str = "localhost"
+    port: int = 3306
+    database: str = "test"
+
+
+@inject
+@dataclass
+class DatabaseConnection:
+    config: DatabaseConfig
+
+    def __post_init__(self):
+        print(f"Creating DB connection to {self.config.host}:{self.config.port}/{self.config.database}")
+
+
+@inject
+@dataclass
+class UserRepository:
+    db_connection: DatabaseConnection
+
+    def get_users(self):
+        print("Fetching users from database")
+        return ["user1", "user2"]
+
+
+@inject
+@dataclass
+class UserService:
+    user_repository: UserRepository
+
+    def list_users(self):
+        return self.user_repository.get_users()
+
+
+# Module configuration
+class AppModule(Module):
+    @singleton
+    @provider
+    def provide_config(self) -> DatabaseConfig:
+        print("Providing DatabaseConfig")
+        return DatabaseConfig(host="prod-db.example.com", port=3306, database="production")
+
+    @provider
+    def provide_db_connection(self, config: DatabaseConfig) -> DatabaseConnection:
+        print("Providing DatabaseConnection")
+        return DatabaseConnection(config=config)
+
+
+def main():
+    print("=== Example 1: Without logging ===")
+    injector_no_log = Injector([AppModule()])
+    service1 = injector_no_log.get(UserService)
+    service1.list_users()
+
+    print("\n=== Example 2: With DEBUG logging ===")
+    # Enable injector debug logging
+    setup_injector_logging()
+
+    injector_with_log = Injector([AppModule()])
+    service2 = injector_with_log.get(UserService)
+    service2.list_users()
+
+    print("\n=== Example 3: Verify singleton behavior ===")
+    config1 = injector_with_log.get(DatabaseConfig)
+    config2 = injector_with_log.get(DatabaseConfig)
+    print(f"Same config instance? {config1 is config2}")
+
+
+if __name__ == "__main__":
+    main()

--- a/product_info_export_main.py
+++ b/product_info_export_main.py
@@ -2,16 +2,46 @@
 
 import sys
 import logging
+import os
 from injector import Injector
 from batch.product_info_csv_export_processor import ProductInfoCsvExportProcessorImpl
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
+def setup_injector_logging():
+    """
+    Enable debug logging for injector to trace dependency injection
+
+    This will output detailed information about:
+    - Dependency resolution process
+    - Provider usage
+    - Object creation
+    - Singleton behavior
+    """
+    injector_logger = logging.getLogger('injector')
+    injector_logger.setLevel(logging.DEBUG)
+
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    )
+    handler.setFormatter(formatter)
+    injector_logger.addHandler(handler)
+
+    logger.info("Injector debug logging enabled")
+
+
 def main():
     """Main function for Product Info CSV Export"""
     try:
         logger.info("Starting Product Info CSV Export Application...")
+
+        # Enable injector logging if DEBUG environment variable is set
+        if os.getenv('DEBUG', 'false').lower() == 'true':
+            setup_injector_logging()
 
         # Create injector and get processor
         injector = Injector()

--- a/product_info_export_main_README.md
+++ b/product_info_export_main_README.md
@@ -1,0 +1,162 @@
+# Product Info CSV Export - Injector Logging Guide
+
+## Overview
+
+The `product_info_export_main.py` script now supports detailed dependency injection logging for debugging and understanding the application's dependency tree.
+
+## Usage
+
+### Normal Execution (Without Logging)
+
+```bash
+python product_info_export_main.py
+```
+
+Output:
+```
+INFO:__main__:Starting Product Info CSV Export Application...
+INFO:batch.product_info_csv_export_processor:=== Starting Product Info CSV Export Process ===
+...
+```
+
+### Debug Mode (With Injector Logging)
+
+```bash
+# On Linux/macOS/Git Bash
+export DEBUG=true && python product_info_export_main.py
+
+# On Windows CMD
+set DEBUG=true && python product_info_export_main.py
+
+# On Windows PowerShell
+$env:DEBUG="true"; python product_info_export_main.py
+```
+
+## Debug Output Example
+
+When `DEBUG=true` is set, you'll see detailed dependency injection traces:
+
+```
+INFO:__main__:Starting Product Info CSV Export Application...
+INFO:__main__:Injector debug logging enabled
+
+> Injector.get(<class 'ProductInfoCsvExportProcessorImpl'>) using <ClassProvider>
+> Creating <class 'ProductInfoCsvExportProcessorImpl'> object
+> Providing {'product_info_service': <class 'ProductInfoService'>}
+>> Injector.get(<class 'ProductInfoService'>) using <ClassProvider>
+>> Creating <class 'ProductInfoService'> object
+>> Providing {'product_info_repository': <class 'ProductInfoRepository'>}
+>>> Injector.get(<class 'ProductInfoRepository'>) using <ClassProvider>
+>>> Creating <class 'ProductInfoRepository'> object
+>>> Providing {'db_session': <class 'Test2DatabaseSession'>}
+>>>> Injector.get(<class 'Test2DatabaseSession'>, scope=SingletonScope) using <ClassProvider>
+>>>> Creating <class 'Test2DatabaseSession'> object
+>>>> Providing {'engine': <class 'Test2DatabaseEngine'>}
+>>>>> Injector.get(<class 'Test2DatabaseEngine'>, scope=SingletonScope) using <ClassProvider>
+>>>>> Creating <class 'Test2DatabaseEngine'> object
+>>>>> Providing {'config': <class 'DatabaseConfig'>}
+>>>>>> Injector.get(<class 'DatabaseConfig'>, scope=SingletonScope) using <ClassProvider>
+>>>>>> Creating <class 'DatabaseConfig'> object
+>>>>>>  -> <DatabaseConfig object>
+>>>>>  -> Test2DatabaseEngine(config=<DatabaseConfig object>)
+>>>>  -> <Test2DatabaseSession object>
+>>>  -> ProductInfoRepository(db_session=<Test2DatabaseSession object>)
+>>  -> ProductInfoService(product_info_repository=ProductInfoRepository(...))
+>  -> ProductInfoCsvExportProcessorImpl(product_info_service=ProductInfoService(...))
+```
+
+## Dependency Tree Visualization
+
+The indentation (`>`, `>>`, `>>>`, etc.) shows the depth of dependency injection:
+
+```
+ProductInfoCsvExportProcessorImpl
+└── ProductInfoService
+    └── ProductInfoRepository
+        └── Test2DatabaseSession (Singleton)
+            └── Test2DatabaseEngine (Singleton)
+                └── DatabaseConfig (Singleton)
+```
+
+## Understanding the Logs
+
+### Key Information in Debug Logs
+
+1. **Injector.get()**: Shows what's being requested
+   - Interface/Class being resolved
+   - Scope (NoScope, SingletonScope)
+   - Provider type (ClassProvider, CallableProvider)
+
+2. **Creating object**: Shows object instantiation
+   - Class being created
+   - Additional kwargs passed
+
+3. **Providing**: Shows dependencies being injected
+   - Parameter name and type
+   - Function receiving the injection
+
+4. **Result (->)**: Shows the created instance
+
+### Singleton Behavior
+
+Notice that `DatabaseConfig`, `Test2DatabaseEngine`, and `Test2DatabaseSession` are created with `SingletonScope`:
+- They are created only once
+- Subsequent requests return the same instance
+
+## Use Cases
+
+### 1. Debugging Injection Issues
+
+If you encounter dependency injection errors, enable debug logging to see exactly where it fails:
+
+```bash
+DEBUG=true python product_info_export_main.py
+```
+
+### 2. Understanding Application Architecture
+
+Use the logs to visualize how components are wired together:
+- Which classes depend on what
+- What's singleton vs transient
+- Order of initialization
+
+### 3. Performance Analysis
+
+Debug logs can help identify:
+- Heavy initialization in constructors
+- Unnecessary object creation
+- Singleton reuse patterns
+
+## Disabling Logging
+
+To disable injector logging, simply run without the DEBUG flag:
+
+```bash
+python product_info_export_main.py
+```
+
+Or explicitly set:
+
+```bash
+DEBUG=false python product_info_export_main.py
+```
+
+## Integration with Other Tools
+
+The injector logging integrates seamlessly with:
+- SQLAlchemy logging (shown as INFO level)
+- Application logging (batch processor logs)
+- Custom business logic logging
+
+## Best Practices
+
+1. **Development**: Enable `DEBUG=true` during development
+2. **Testing**: Keep logging on to verify dependency wiring
+3. **Production**: Disable debug logging for performance
+4. **CI/CD**: Use debug logs in failing test cases for diagnosis
+
+## Related Files
+
+- `examples/injector_logging_example.py` - Basic injector logging example
+- `examples/README.md` - Comprehensive injector logging guide
+- `product_info_export_main.py` - This script with logging support


### PR DESCRIPTION
## 概要
product_info_export_main.pyでInjectorのログを出力できるようにする

## 実装内容
下記ソースを実施する時、Injectorのログを出力するように修正:
- product_info_export_main.py

## 変更内容
- Injectorのデバッグログを有効化する関数を追加
- 環境変数DEBUGでログ出力を制御
- 依存性注入のトレース情報を出力

## 関連Issue
Closes #9